### PR TITLE
Fix dashboard filter layout

### DIFF
--- a/Front/static/css/area-dashboard/main-dashboard-template.css
+++ b/Front/static/css/area-dashboard/main-dashboard-template.css
@@ -145,8 +145,9 @@
 }
 
 .lista-opcoes-form-filtro-dashboard {
-  display: grid;
-  grid-auto-flow: column;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
   gap: 10px;
   padding-bottom: 10px;
   box-sizing: border-box;
@@ -177,6 +178,12 @@
   display: flex;
   align-items: center;
   gap: 5px;
+  flex-wrap: wrap;
+}
+
+.dashboard-periodo-container .input-filtro-dashboard {
+  flex: 1 1 150px;
+  min-width: 120px;
 }
 
 /* Separador entre Datas */
@@ -216,8 +223,8 @@
   }
 
   .lista-opcoes-form-filtro-dashboard {
-    display: grid;
-    grid-auto-flow: row;
+    display: flex;
+    flex-direction: column;
     gap: 10px;
     padding-bottom: 10px;
   }


### PR DESCRIPTION
## Summary
- prevent filter inputs from overflowing small cards
- allow filter fields to wrap on smaller screens

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6848833f08688332b58e2cc6541bb4e8