### PR TITLE
Ajusta autocomplete do fornecedor em despesas

### DIFF
--- a/Front/despesa_incluir.html
+++ b/Front/despesa_incluir.html
@@ -95,14 +95,14 @@
                         <div class="campo">
                           <label for="cnpj_cpf_fornecedor">CNPJ / CPF fornecedor</label>
                           <input type="text" id="cnpj_cpf_fornecedor" class="form-control">
-                          <!-- <div id="loading-indicator-cnpj" class="loading-indicator">Carregando...</div> -->
-                          <!-- <ul class="suggestions" id="suggestions-cnpj"></ul> -->
+                          <div id="loading-indicator-cnpj" class="loading-indicator">Carregando...</div>
+                          <div id="suggestions-cnpj" class="suggestions"></div>
                         </div>
                         <div class="campo">
                           <label for="nome_fornecedor">Nome do fornecedor</label>
                           <input type="text" id="nome_fornecedor" class="form-control form-control-md">
-                          <!--  <div id="loading-indicator-nome" class="loading-indicator">Carregando...</div> -->
-                          <!-- <ul class="suggestions" id="suggestions-nome"></ul> -->
+                          <div id="loading-indicator-nome" class="loading-indicator">Carregando...</div>
+                          <div id="suggestions-nome" class="suggestions"></div>
                         </div>
                         <div class="campo">
                           <label for="email_fornecedor">Email do fornecedor</label>

--- a/Front/static/JS/DespesaSearchAll.js
+++ b/Front/static/JS/DespesaSearchAll.js
@@ -1,163 +1,107 @@
-document.addEventListener("DOMContentLoaded", function () {
-  const inputFieldRefPoli = document.getElementById("indicacao");
-  const suggestionsDivRefPoli = document.getElementById("suggestions-ref-poli");
-  const loadingIndicatorRefPoli = document.getElementById("loading-indicator");
+// Autocomplete para campos de fornecedor na tela de Despesa
+// Busca dados da API de contatos e preenche nome e CNPJ/CPF
 
-  let selectedIndexRefPoli = -1;
-  let currentSuggestionsRefPoli = [];
-  let isSelectingSuggestionRefPoli = false;
-  let selectedSuggestionNameRefPoli = null;
+document.addEventListener('DOMContentLoaded', () => {
+  const nomeField = document.getElementById('nome_fornecedor');
+  const cnpjField = document.getElementById('cnpj_cpf_fornecedor');
+  const suggestionsNome = document.getElementById('suggestions-nome');
+  const suggestionsCnpj = document.getElementById('suggestions-cnpj');
+  const loadingNome = document.getElementById('loading-indicator-nome');
+  const loadingCnpj = document.getElementById('loading-indicator-cnpj');
 
-  const debounceRefPoli = (func, delay) => {
-    let timeout;
+  const showLoading = (el) => { if (el) el.style.display = 'block'; };
+  const hideLoading = (el) => { if (el) el.style.display = 'none'; };
+
+  const debounce = (fn, delay) => {
+    let t;
     return (...args) => {
-      clearTimeout(timeout);
-      timeout = setTimeout(() => func(...args), delay);
+      clearTimeout(t);
+      t = setTimeout(() => fn(...args), delay);
     };
   };
 
-  const showLoadingRefPoli = () => {
-    loadingIndicatorRefPoli.style.display = "inline-block";
-  };
-
-  const hideLoadingRefPoli = () => {
-    loadingIndicatorRefPoli.style.display = "none";
-  };
-
-  const showErrorRefPoli = (message) => {
-    let errorDivRefPoli = document.querySelector(".message-error-refpoli");
-    if (!errorDivRefPoli) {
-      errorDivRefPoli = document.createElement("div");
-      errorDivRefPoli.classList.add("message-error", "message-error-refpoli");
-      document.body.appendChild(errorDivRefPoli);
-    }
-    errorDivRefPoli.textContent = message;
-    errorDivRefPoli.classList.add("show");
-
-    setTimeout(() => {
-      errorDivRefPoli.classList.remove("show");
-    }, 3000);
-  };
-
-  const fetchSuggestionsRefPoli = async (query) => {
-    // Obtém a URL base do config.js com base no ambiente atual
+  const fetchFornecedor = async (query, fs) => {
     const baseURL = Config.BASE_URL[Config.ENVIRONMENT];
-
-    // Obtém o endpoint para buscar contatos
     const endpoint = Config.API_ENDPOINTS.CONTACT_SEARCH_ALL;
-
-    // Verifica se baseURL e endpoint estão definidos
-    if (!baseURL || !endpoint) {
-      console.error("Configuração de URL base ou endpoint não encontrada.");
-      showErrorRefPoli("Erro de configuração. Tente novamente mais tarde.");
-      return {
-        error: true,
-        message: "Configuração de URL base ou endpoint não encontrada.",
-      };
-    }
-
-    // Define o parâmetro `tp` como 2 fixo
-    const tp = 2;
-
-    // Monta a URL completa utilizando as variáveis do config.js
-    const url = `${baseURL}${endpoint}/${encodeURIComponent(
-      query
-    )}?tp=${tp}&fs=${fieldSearch || ""}`;
-
-    // Exibe o indicador de carregamento
-    showLoadingRefPoli();
-
+    const url = `${baseURL}${endpoint}/${encodeURIComponent(query)}?fs=${fs}&qt=3`;
     try {
-      const response = await fetch(url);
-
-      if (!response.ok) {
-        throw new Error("Falha na comunicação com a API.");
-      }
-
-      const results = await response.json();
-      return results.DADOS || [];
-    } catch (error) {
-      console.error("Erro na busca:", error.message);
-      showErrorRefPoli("Erro ao buscar dados. Tente novamente.");
-      return { error: true, message: error.message };
-    } finally {
-      // Esconde o indicador de carregamento
-      hideLoadingRefPoli();
+      const resp = await fetch(url);
+      if (!resp.ok) throw new Error('Erro ao buscar dados');
+      const data = await resp.json();
+      return data.DADOS || [];
+    } catch (err) {
+      console.error('Erro na busca:', err);
+      return [];
     }
   };
 
-  // Função para exibir as sugestões
-  function showSuggestions(suggestions, target) {
-    const suggestionsList = document.getElementById(`suggestions-${target}`);
-    suggestionsList.innerHTML = "";
-
-    if (suggestions.error) {
-      suggestionsList.innerHTML = `<li class="error">${suggestions.message}</li>`;
-      setTimeout(() => {
-        suggestionsList.innerHTML = "";
-      }, 3000); // Fecha a lista após 3 segundos
-    } else if (suggestions.length === 0) {
-      suggestionsList.innerHTML = "<li>Nenhuma correspondência encontrada</li>";
-      setTimeout(() => {
-        suggestionsList.innerHTML = "";
-      }, 3000); // Fecha a lista após 3 segundos
+  const displaySuggestions = (list, container, fillFn) => {
+    container.innerHTML = '';
+    if (list.length === 0) {
+      const li = document.createElement('li');
+      li.textContent = 'Nenhuma correspondência encontrada';
+      container.appendChild(li);
     } else {
-      suggestions.forEach((item) => {
-        const li = document.createElement("li");
+      const ul = document.createElement('ul');
+      list.forEach((item) => {
+        const li = document.createElement('li');
         li.textContent = `${item.name} - ${item.cnpj_cpf}`;
-        li.addEventListener("click", () => fillForm(item));
-        suggestionsList.appendChild(li);
+        li.addEventListener('click', () => {
+          fillFn(item);
+          container.innerHTML = '';
+          container.classList.remove('visible');
+        });
+        ul.appendChild(li);
       });
+      container.appendChild(ul);
     }
-  }
+    container.classList.add('visible');
+  };
 
-  // Função para preencher o formulário ao selecionar uma sugestão
-  function fillForm(item) {
-    document.getElementById("cnpj_cpf_fornecedor").value = item.cnpj_cpf;
-    document.getElementById("nome_fornecedor").value = item.name;
+  const handleNomeInput = debounce(async () => {
+    const query = nomeField.value.trim();
+    if (query.length >= 3) {
+      showLoading(loadingNome);
+      const results = await fetchFornecedor(query, 1);
+      displaySuggestions(results, suggestionsNome, (item) => {
+        nomeField.value = item.name;
+        cnpjField.value = item.cnpj_cpf;
+      });
+      hideLoading(loadingNome);
+    } else {
+      suggestionsNome.innerHTML = '';
+      suggestionsNome.classList.remove('visible');
+    }
+  }, 300);
 
-    // Limpa as sugestões após a seleção
-    document.getElementById("suggestions-cnpj").innerHTML = "";
-    document.getElementById("suggestions-nome").innerHTML = "";
-  }
+  const handleCnpjInput = debounce(async () => {
+    const query = cnpjField.value.replace(/\D/g, '');
+    if (query.length >= 3) {
+      showLoading(loadingCnpj);
+      const results = await fetchFornecedor(query, 2);
+      displaySuggestions(results, suggestionsCnpj, (item) => {
+        nomeField.value = item.name;
+        cnpjField.value = item.cnpj_cpf;
+      });
+      hideLoading(loadingCnpj);
+    } else {
+      suggestionsCnpj.innerHTML = '';
+      suggestionsCnpj.classList.remove('visible');
+    }
+  }, 300);
 
-  // Função debounce para limitar a quantidade de requisições
-  function debounce(func, wait) {
-    let timeout;
-    return function (...args) {
-      const context = this;
-      clearTimeout(timeout);
-      timeout = setTimeout(() => func.apply(context, args), wait);
-    };
-  }
+  nomeField.addEventListener('input', handleNomeInput);
+  cnpjField.addEventListener('input', () => {
+    MascaraUtils.aplicarMascaraCPFCNPJ(cnpjField);
+    handleCnpjInput();
+  });
 
-  // Adiciona o evento de input para o campo CNPJ/CPF
-  document.getElementById("cnpj_cpf_fornecedor").addEventListener(
-    "input",
-    debounce(async function () {
-      const query = this.value;
-      if (query.length >= 3) {
-        const suggestions = await fetchSuggestionsRefPoli(query, 2, "cnpj");
-        showSuggestions(suggestions, "cnpj");
-      } else {
-        document.getElementById("suggestions-cnpj").innerHTML = "";
-        document.getElementById("suggestions-cnpj").classList.remove("visible");
-      }
-    }, 300)
-  );
-
-  // Adiciona o evento de input para o campo Nome
-  document.getElementById("nome_fornecedor").addEventListener(
-    "input",
-    debounce(async function () {
-      const query = this.value;
-      if (query.length >= 3) {
-        const suggestions = await fetchSuggestionsRefPoli(query, 1, "nome");
-        showSuggestions(suggestions, "nome");
-      } else {
-        document.getElementById("suggestions-nome").innerHTML = "";
-        document.getElementById("suggestions-nome").classList.remove("visible");
-      }
-    }, 300)
-  );
+  document.addEventListener('click', (e) => {
+    if (!suggestionsNome.contains(e.target) && e.target !== nomeField) {
+      suggestionsNome.classList.remove('visible');
+    }
+    if (!suggestionsCnpj.contains(e.target) && e.target !== cnpjField) {
+      suggestionsCnpj.classList.remove('visible');
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- exibe divs de loading e sugestoes na tela de inclusão de despesas
- reimplementa DespesaSearchAll.js para buscar fornecedor por nome ou CNPJ/CPF

## Testing
- `node --check Front/static/JS/DespesaSearchAll.js`

------
https://chatgpt.com/codex/tasks/task_e_6848ed7f53648332a2d1a542be898e01