### PR TITLE
Padroniza upload de arquivos em pleito

### DIFF
--- a/Front/pleito_incluir.html
+++ b/Front/pleito_incluir.html
@@ -215,28 +215,34 @@
                   <div class="area-interna-containerContent-template-content area-interna-containerContent-template-not-header">
                     <div class="card-session active">
                       <fieldset>
-                        <div class="campo tabelaArquivosAnexados">
-                          <div class="campo btn-file">
-                            <label for="anexar_documento" class="file-label">Anexar documento</label>
-                            <input type="file" id="anexar_documento" name="anexar_documento" class="file-input" multiple onchange="atualizarListaArquivos()">
+                        <div class="doc-upload-section">
+                          <h3 class="doc-upload-section-title">Arquivos</h3>
+
+                          <div class="doc-upload-option">
+                            <div class="doc-upload-area" id="uploadArea">
+                              <div class="doc-upload-icon">📁</div>
+                              <p class="doc-upload-text">Arraste o arquivo ou clique para selecionar</p>
+                              <input class="doc-upload-file-input" type="file" id="anexar_documento" name="anexar_documento" multiple>
+                            </div>
                           </div>
-                          <p id="contadorArquivosAnexados" class="titulo-area-tabela">Total de contatos encontrados: 0</p>
-                          <div class="tabela-historico">
-                            <table id="tabelaArquivosAnexados">
-                              <thead>
-                                <tr>
-                                  <th class="hidden-column">ID</th>
-                                  <th>Nome</th>
-                                  <th>Tipo</th>
-                                  <th>Ações</th>
-                                </tr>
-                              </thead>
-                              <tbody>
-                                <!-- Arquivos anexados serão listados aqui -->
-                              </tbody>
-                            </table>
-                            <div class="loading-indicator" id="loading-indicator">Carregando...</div>
-                          </div>
+                        </div>
+
+                        <p id="contadorArquivosAnexados" class="titulo-area-tabela">Total de contatos encontrados: 0</p>
+                        <div class="tabela-historico">
+                          <table id="tabelaArquivosAnexados">
+                            <thead>
+                              <tr>
+                                <th class="hidden-column">ID</th>
+                                <th>Nome</th>
+                                <th>Tipo</th>
+                                <th>Ações</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              <!-- Arquivos anexados serão listados aqui -->
+                            </tbody>
+                          </table>
+                          <div class="loading-indicator" id="loading-indicator">Carregando...</div>
                         </div>
                       </fieldset>
 
@@ -272,6 +278,46 @@
   <script src="./static/js/ContatoIncluirListaReferenciaPolitica.js" defer></script>
   <script src="./static/js/IncluirPleito.js" defer></script>
   <script src="./static/js/PleitoIncluirListaArquivos.js" defer></script>
+
+  <script>
+    function getCSSVariable(varName) {
+      return getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
+    }
+
+    const fileInput = document.getElementById('anexar_documento');
+    fileInput.addEventListener('change', function () {
+      atualizarListaArquivos();
+    });
+
+    const uploadArea = document.getElementById('uploadArea');
+
+    uploadArea.addEventListener('dragover', function (e) {
+      e.preventDefault();
+      uploadArea.style.borderColor = '#3498db';
+      uploadArea.style.backgroundColor = 'rgba(52, 152, 219, 0.1)';
+    });
+
+    uploadArea.addEventListener('dragleave', function (e) {
+      e.preventDefault();
+      uploadArea.style.borderColor = getCSSVariable('--input-border');
+      uploadArea.style.backgroundColor = 'rgba(52, 152, 219, 0.05)';
+    });
+
+    uploadArea.addEventListener('drop', function (e) {
+      e.preventDefault();
+      uploadArea.style.borderColor = getCSSVariable('--input-border');
+      uploadArea.style.backgroundColor = 'rgba(52, 152, 219, 0.05)';
+
+      const dt = e.dataTransfer;
+      const files = dt.files;
+
+      if (files.length) {
+        fileInput.files = files;
+        const event = new Event('change');
+        fileInput.dispatchEvent(event);
+      }
+    });
+  </script>
 
 </body>
 


### PR DESCRIPTION
## Resumo
- remove exibição individual de arquivo e campo de link em *pleito_incluir.html*
- mantém somente área `doc-upload-area` para selecionar ou arrastar arquivos
- simplifica o script de upload usando lista da tabela

## Testes
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848f9fae77c833296a12e03fc0374d3