### PR TITLE
Atualiza upload de documentos em despesa_incluir

### DIFF
--- a/Front/despesa_incluir.html
+++ b/Front/despesa_incluir.html
@@ -182,12 +182,27 @@
                             <option value="Outro">Outro</option>
                           </select>
                         </div>
-                        <div class="campo btn-file">
-                          <label for="anexar_documento" class="file-label">Anexar documento</label>
-                          <input type="file" id="anexar_documento" name="anexar_documento" class="file-input" onchange="atualizarListaArquivos(this, 'tabelaArquivosAba2', 'especie_documento_aba2')">
+                        <div class="doc-upload-section">
+                          <h3 class="doc-upload-section-title">Arquivo</h3>
+
+                          <div class="doc-upload-option">
+                            <div class="doc-upload-area" id="uploadAreaAba2">
+                              <div class="doc-upload-icon">📁</div>
+                              <p class="doc-upload-text">Arraste o arquivo ou clique para selecionar</p>
+                              <input class="doc-upload-file-input" type="file" id="anexar_documento_aba2" name="anexar_documento_aba2" multiple disabled>
+                            </div>
+                          </div>
+
+                          <div class="doc-upload-option">
+                            <div class="doc-upload-or">ou</div>
+                            <div class="doc-upload-link-container">
+                              <span class="doc-upload-link-icon">🔗</span>
+                              <input class="doc-upload-link" type="text" id="linkDocAba2" name="linkDocAba2" placeholder="Insira o link do documento (https://)">
+                            </div>
+                          </div>
                         </div>
 
-                        <p id="contadorArquivos">Total de arquivos adicionados: 0</p>
+                        <p id="contadorArquivosAba2" class="titulo-area-tabela">Total de arquivos adicionados: 0</p>
                         <!-- Tabela para listar os arquivos anexados -->
                         <div class="tabela-historico">
                           <table id="tabelaArquivosAba2">
@@ -323,6 +338,41 @@
                           <label for="cc_multa_id">ID Conta Corrente multa</label>
                           <input type="text" id="cc_multa_id" name="cc_multa_id">
                         </div>
+
+                        <div class="campo">
+                          <label for="especie_documento_pagamento">Espécie documento</label>
+                          <select id="especie_documento_aba3" name="especie_documento_pagamento">
+                            <option value="">Selecione</option>
+                            <option value="cupomFiscal">Cupom Fiscal</option>
+                            <option value="duplicata">Duplicata</option>
+                            <option value="fatura">Fatura</option>
+                            <option value="notaFiscal">notaFiscal</option>
+                            <option value="recibo">Recibo</option>
+                            <option value="Outro">Outro</option>
+                          </select>
+                        </div>
+
+                        <div class="doc-upload-section">
+                          <h3 class="doc-upload-section-title">Arquivo</h3>
+
+                          <div class="doc-upload-option">
+                            <div class="doc-upload-area" id="uploadAreaAba3">
+                              <div class="doc-upload-icon">📁</div>
+                              <p class="doc-upload-text">Arraste o arquivo ou clique para selecionar</p>
+                              <input class="doc-upload-file-input" type="file" id="anexar_documento_aba3" name="anexar_documento_aba3" multiple disabled>
+                            </div>
+                          </div>
+
+                          <div class="doc-upload-option">
+                            <div class="doc-upload-or">ou</div>
+                            <div class="doc-upload-link-container">
+                              <span class="doc-upload-link-icon">🔗</span>
+                              <input class="doc-upload-link" type="text" id="linkDocAba3" name="linkDocAba3" placeholder="Insira o link do documento (https://)">
+                            </div>
+                          </div>
+                        </div>
+
+                        <p id="contadorArquivosAba3" class="titulo-area-tabela">Total de arquivos adicionados: 0</p>
                       </fieldset>
 
                       <!-- Tabela para listar os arquivos anexados -->

--- a/Front/static/JS/DespesaIncluirListaArquivos.js
+++ b/Front/static/JS/DespesaIncluirListaArquivos.js
@@ -1,18 +1,14 @@
-let idArquivo = 1; // Inicializa um contador para os IDs dos arquivos
-const arquivosMap = new Map(); // Armazena os arquivos adicionados para controle
-const contadorArquivos = document.getElementById("contadorArquivos");
+let idArquivo = 1;
+const arquivosMap = new Map();
 
 function atualizarListaArquivos(inputFile, tabelaId, selectId) {
   const tabelaArquivos = document.getElementById(tabelaId);
   const tbody = tabelaArquivos.querySelector("tbody");
 
-  // Obtenha o valor selecionado do campo <select> específico para cada aba
   const selectElement = document.getElementById(selectId);
-  const especieDocumento =
-    selectElement.options[selectElement.selectedIndex].text;
+  const especieDocumento = selectElement.options[selectElement.selectedIndex].text;
   const valorSelecionado = selectElement.value;
 
-  // Verifica se um valor foi selecionado
   if (!valorSelecionado) {
     alert("Por favor, selecione uma espécie de documento.");
     return;
@@ -23,41 +19,49 @@ function atualizarListaArquivos(inputFile, tabelaId, selectId) {
     const tr = document.createElement("tr");
     tr.setAttribute("data-id", idArquivo);
     tr.classList.add("tabela-historico", "table-row-fade-in");
-    tr.innerHTML = `
-      <td data-label="ID">${idArquivo}</td>
-      <td data-label="Data">${new Date().toLocaleDateString()}</td>
-      <td data-label="Tipo">${arquivo.type}</td>
-      <td data-label="Nome">${arquivo.name}</td>
-      <td data-label="Espécie Documento">${especieDocumento}</td>
-      <td>
-        <div class="icone-container">
-          <img src="./static/imagens/icones/excluir.svg" alt="Excluir" class="icone-excluir" onclick="excluirArquivo(${idArquivo}, '${tabelaId}')">
-        </div>
-      </td>
-    `;
+
+    let rowHtml = "";
+    if (tabelaId === "tabelaArquivosAba3") {
+      rowHtml = `
+        <td data-label="ID">${idArquivo}</td>
+        <td data-label="Data">${new Date().toLocaleDateString()}</td>
+        <td data-label="Espécie Documento">${especieDocumento}</td>
+        <td data-label="Arquivo">${arquivo.name}</td>
+        <td>
+          <div class="icone-container">
+            <img src="./static/imagens/icones/excluir.svg" alt="Excluir" class="icone-excluir" onclick="excluirArquivo(${idArquivo}, '${tabelaId}')">
+          </div>
+        </td>`;
+    } else {
+      rowHtml = `
+        <td data-label="ID">${idArquivo}</td>
+        <td data-label="Data">${new Date().toLocaleDateString()}</td>
+        <td data-label="Tipo">${arquivo.type}</td>
+        <td data-label="Nome">${arquivo.name}</td>
+        <td data-label="Espécie Documento">${especieDocumento}</td>
+        <td>
+          <div class="icone-container">
+            <img src="./static/imagens/icones/excluir.svg" alt="Excluir" class="icone-excluir" onclick="excluirArquivo(${idArquivo}, '${tabelaId}')">
+          </div>
+        </td>`;
+    }
+
+    tr.innerHTML = rowHtml;
     tbody.appendChild(tr);
 
     arquivosMap.set(idArquivo, { valor: valorSelecionado });
     idArquivo++;
 
-    // Envio do arquivo para o servidor (simulação)
     const formData = new FormData();
     formData.append("file", arquivo);
 
-    fetch("/upload", {
-      method: "POST",
-      body: formData,
-    })
-      .then((response) => {
-        console.log("Upload realizado com sucesso");
-      })
-      .catch((error) => {
-        console.error("Erro ao enviar o arquivo:", error);
-      });
+    fetch("/upload", { method: "POST", body: formData })
+      .then(() => console.log("Upload realizado com sucesso"))
+      .catch((error) => console.error("Erro ao enviar o arquivo:", error));
   }
 
-  // Atualiza o contador de itens
-  atualizarContadorArquivos();
+  atualizarContadorArquivos(tabelaId);
+  inputFile.value = "";
 }
 
 function excluirArquivo(id, tabelaId) {
@@ -68,20 +72,91 @@ function excluirArquivo(id, tabelaId) {
     setTimeout(() => {
       tr.remove();
       arquivosMap.delete(id);
-
-      // Atualiza o contador de itens
-      atualizarContadorArquivos();
-    }, 500); // Tempo para a animação de remoção
+      atualizarContadorArquivos(tabelaId);
+    }, 500);
   }
 }
 
-function atualizarContadorArquivos() {
-  const tabelaArquivos = document.getElementById("tabelaArquivosAba2");
+function atualizarContadorArquivos(tabelaId) {
+  const tabelaArquivos = document.getElementById(tabelaId);
   const tbody = tabelaArquivos.querySelector("tbody");
   const numItens = tbody.querySelectorAll("tr").length;
-  contadorArquivos.textContent = `Total de arquivos adicionados: ${numItens}`;
-  contadorArquivos.classList.add("contador-pulse");
+  const contadorId = tabelaId === "tabelaArquivosAba3" ? "contadorArquivosAba3" : "contadorArquivosAba2";
+  const contadorElement = document.getElementById(contadorId);
+  contadorElement.textContent = `Total de arquivos adicionados: ${numItens}`;
+  contadorElement.classList.add("contador-pulse");
   setTimeout(() => {
-    contadorArquivos.classList.remove("contador-pulse");
+    contadorElement.classList.remove("contador-pulse");
   }, 300);
 }
+
+function configurarSelecaoArquivo(selectId, inputId) {
+  const selectElement = document.getElementById(selectId);
+  const inputFile = document.getElementById(inputId);
+  if (!selectElement || !inputFile) return;
+  inputFile.disabled = true;
+  selectElement.addEventListener("change", () => {
+    if (selectElement.value) {
+      inputFile.disabled = false;
+    } else {
+      inputFile.disabled = true;
+      inputFile.value = "";
+    }
+  });
+}
+
+function configurarDragAndDrop(areaId, inputId) {
+  const uploadArea = document.getElementById(areaId);
+  const fileInput = document.getElementById(inputId);
+  if (!uploadArea || !fileInput) return;
+
+  function getCSSVariable(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+
+  uploadArea.addEventListener("dragover", function (e) {
+    e.preventDefault();
+    uploadArea.style.borderColor = "#3498db";
+    uploadArea.style.backgroundColor = "rgba(52, 152, 219, 0.1)";
+  });
+
+  uploadArea.addEventListener("dragleave", function (e) {
+    e.preventDefault();
+    uploadArea.style.borderColor = getCSSVariable("--input-border");
+    uploadArea.style.backgroundColor = "rgba(52, 152, 219, 0.05)";
+  });
+
+  uploadArea.addEventListener("drop", function (e) {
+    e.preventDefault();
+    uploadArea.style.borderColor = getCSSVariable("--input-border");
+    uploadArea.style.backgroundColor = "rgba(52, 152, 219, 0.05)";
+
+    const dt = e.dataTransfer;
+    const files = dt.files;
+
+    if (files.length) {
+      fileInput.files = files;
+      const event = new Event("change");
+      fileInput.dispatchEvent(event);
+    }
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  configurarSelecaoArquivo("especie_documento_aba2", "anexar_documento_aba2");
+  configurarSelecaoArquivo("especie_documento_aba3", "anexar_documento_aba3");
+
+  const inputAba2 = document.getElementById("anexar_documento_aba2");
+  const inputAba3 = document.getElementById("anexar_documento_aba3");
+
+  if (inputAba2) {
+    inputAba2.addEventListener("change", () => atualizarListaArquivos(inputAba2, "tabelaArquivosAba2", "especie_documento_aba2"));
+    configurarDragAndDrop("uploadAreaAba2", "anexar_documento_aba2");
+  }
+
+  if (inputAba3) {
+    inputAba3.addEventListener("change", () => atualizarListaArquivos(inputAba3, "tabelaArquivosAba3", "especie_documento_aba3"));
+    configurarDragAndDrop("uploadAreaAba3", "anexar_documento_aba3");
+  }
+});
+


### PR DESCRIPTION
## Summary
- padroniza upload na aba de comprovante de despesa com *doc-upload-area*
- cria upload igual na aba de comprovante de pagamento
- generaliza script `DespesaIncluirListaArquivos.js` para lidar com as duas abas e habilitar upload apenas apos escolha da espécie

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68498e65dff08332bb85b6f99e863bbd