### PR TITLE
Implementa feedback mais claro para upload de despesa

### DIFF
--- a/Front/despesa_incluir.html
+++ b/Front/despesa_incluir.html
@@ -181,7 +181,7 @@
                             <option value="recibo">Recibo</option>
                             <option value="Outro">Outro</option>
                           </select>
-                          <p class="gc-error-message" id="msgEspecieAba2" style="display: none;">Escolha a espécie antes de anexar o arquivo.</p>
+                          <p class="gc-error-message" id="msgEspecieAba2" style="display: none;">Selecione a espécie do documento para liberar a seleção de um arquivo.</p>
                         </div>
                         <div class="doc-upload-section">
                           <h3 class="doc-upload-section-title">Arquivo</h3>
@@ -191,7 +191,7 @@
                               <div class="doc-upload-icon">📁</div>
                               <p class="doc-upload-text">Arraste o arquivo ou clique para selecionar</p>
                               <input class="doc-upload-file-input" type="file" id="anexar_documento_aba2" name="anexar_documento_aba2" multiple disabled>
-                              <span class="tooltiptext">Escolha a espécie do documento</span>
+                              <span class="tooltiptext">Selecione a espécie do documento</span>
                             </div>
                           </div>
 
@@ -352,7 +352,7 @@
                             <option value="recibo">Recibo</option>
                             <option value="Outro">Outro</option>
                           </select>
-                          <p class="gc-error-message" id="msgEspecieAba3" style="display: none;">Escolha a espécie antes de anexar o arquivo.</p>
+                          <p class="gc-error-message" id="msgEspecieAba3" style="display: none;">Selecione a espécie do documento para liberar a seleção de um arquivo.</p>
                         </div>
 
 
@@ -364,7 +364,7 @@
                               <div class="doc-upload-icon">📁</div>
                               <p class="doc-upload-text">Arraste o arquivo ou clique para selecionar</p>
                               <input class="doc-upload-file-input" type="file" id="anexar_documento_aba3" name="anexar_documento_aba3" multiple disabled>
-                              <span class="tooltiptext">Escolha a espécie do documento</span>
+                              <span class="tooltiptext">Selecione a espécie do documento</span>
                             </div>
                           </div>
 

--- a/Front/static/JS/DespesaIncluirListaArquivos.js
+++ b/Front/static/JS/DespesaIncluirListaArquivos.js
@@ -35,7 +35,7 @@ function atualizarListaArquivos(inputFile, tabelaId, selectId, msgId) {
     let rowHtml = "";
     if (tabelaId === "tabelaArquivosAba3") {
       rowHtml = `
-        <td data-label="ID">${idArquivo}</td>
+        <td data-label="ID" class="hidden-column">${idArquivo}</td>
         <td data-label="Data">${new Date().toLocaleDateString()}</td>
         <td data-label="Espécie Documento">${especieDocumento}</td>
         <td data-label="Arquivo">${arquivo.name}</td>
@@ -46,7 +46,7 @@ function atualizarListaArquivos(inputFile, tabelaId, selectId, msgId) {
         </td>`;
     } else {
       rowHtml = `
-        <td data-label="ID">${idArquivo}</td>
+        <td data-label="ID" class="hidden-column">${idArquivo}</td>
         <td data-label="Data">${new Date().toLocaleDateString()}</td>
         <td data-label="Tipo">${arquivo.type}</td>
         <td data-label="Nome">${arquivo.name}</td>


### PR DESCRIPTION
## Summary
- show warning instructing user to choose document type before uploading
- hide ID column on appended rows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a39e509188332a6f1a64f91cbe5c6