### PR TITLE
Improve responsive breakpoints

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -7,6 +7,8 @@
   --breakpoint-md: 768px;
   --breakpoint-lg: 992px;
   --breakpoint-xl: 1200px;
+  --breakpoint-xs: 480px;
+  --breakpoint-xxs: 360px;
 
   /* Paleta de Cores */
   --color-bg: hsl(247, 65%, 8%);
@@ -2535,5 +2537,42 @@ blockquote cite {
   .btn {
     padding: calc(var(--spacing-sm) * 1.3) calc(var(--spacing-md) * 1);
     font-size: var(--font-size-base);
+  }
+}
+
+@media (max-width: var(--breakpoint-xs)) {
+  .logo {
+    font-size: var(--font-size-lg);
+  }
+  .header-cta {
+    flex-direction: column;
+    gap: var(--spacing-xs);
+  }
+  .hero-title {
+    font-size: var(--font-size-3xl);
+  }
+  .section-title {
+    font-size: var(--font-size-2xl);
+  }
+  .section-subtitle {
+    font-size: var(--font-size-lg);
+  }
+  .hero-cta {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: var(--breakpoint-xxs)) {
+  .hero-title {
+    font-size: 1.8rem;
+  }
+  .section-title {
+    font-size: var(--font-size-xl);
+  }
+  .section-subtitle {
+    font-size: var(--font-size-base);
+  }
+  .btn {
+    padding: var(--spacing-sm) var(--spacing-md);
   }
 }


### PR DESCRIPTION
## Summary
- tweak root theme vars with new breakpoints
- add responsive rules for headers, hero text and buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a41327dfc833288891ccb4efac86d