### PR TITLE
Add edit/delete interactions with tooltips

### DIFF
--- a/Front/centro-de-custo.html
+++ b/Front/centro-de-custo.html
@@ -80,10 +80,10 @@
                   <p><strong>Status:</strong> FECHADO</p>
                 </div>
                 <div class="centroDeCusto-card-footer">
-                  <button class="edit" aria-label="Editar">
+                  <button class="edit" aria-label="Editar" title="Editar">
                     <img src="./static/imagens/icones/editar.svg" alt="Editar">
                   </button>
-                  <button class="delete" aria-label="Excluir">
+                  <button class="delete" aria-label="Excluir" title="Excluir">
                     <img src="./static/imagens/icones/excluir.svg" alt="Excluir">
                   </button>
                 </div>
@@ -121,6 +121,7 @@
   <script src="./static/js/AtualizarAlturaPagina.js" defer></script>
   <script src="./static/js/ModalBTNFloating.js" defer></script>
   <script src="./static/js/ManipularHistorico.js" defer></script>
+  <script src="./static/js/EditDeleteCards.js" defer></script>
 
 </body>
 

--- a/Front/conta-corrente.html
+++ b/Front/conta-corrente.html
@@ -90,10 +90,10 @@
                   <p><strong>Uso:</strong> CAMPANHA | FEFC</p>
                 </div>
                 <div class="contaCorrente-card-footer">
-                  <button class="edit" aria-label="Editar">
+                  <button class="edit" aria-label="Editar" title="Editar">
                     <img src="./static/imagens/icones/editar.svg" alt="Editar">
                   </button>
-                  <button class="delete" aria-label="Excluir">
+                  <button class="delete" aria-label="Excluir" title="Excluir">
                     <img src="./static/imagens/icones/excluir.svg" alt="Excluir">
                   </button>
                 </div>
@@ -179,6 +179,7 @@
   <script src="./static/js/AtualizarAlturaPagina.js" defer></script>
   <script src="./static/js/ModalBTNFloating.js" defer></script>
   <script src="./static/js/ManipularHistorico.js" defer></script>
+  <script src="./static/js/EditDeleteCards.js" defer></script>
 
 </body>
 

--- a/Front/static/JS/EditDeleteCards.js
+++ b/Front/static/JS/EditDeleteCards.js
@@ -1,0 +1,32 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const notification = document.getElementById('notification');
+
+  function showNotification(message) {
+    if (!notification) return;
+    notification.textContent = message;
+    notification.classList.add('show');
+    setTimeout(() => {
+      notification.classList.remove('show');
+    }, 3000);
+  }
+
+  document.querySelectorAll('.edit').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      showNotification('Função de edição não implementada.');
+    });
+  });
+
+  document.querySelectorAll('.delete').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const card = btn.closest('li');
+      if (confirm('Tem certeza que deseja excluir este item?') && card) {
+        card.remove();
+        showNotification('Item excluído com sucesso!');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add EditDeleteCards.js to handle edit/delete buttons on finance pages
- give edit and delete buttons tooltips
- load the new script on Centro de Custo and Conta Corrente pages

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_6850743ea8908332a80cee0593d288ab